### PR TITLE
Smallint: add u10, u12, u14, and u20 custom-sized unsigned integers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,15 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+    tags:
+      - 'v[0-9]+.*'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - develop
+      - 'v[0-9]+.*'
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,15 +21,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo check
+      - run: cargo check --workspace
   no-default:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-        # NB: we have to use either std or alloc here
-      - run: cargo check --no-default-features --features std
-      - run: cargo check --no-default-features --features alloc
+      - run: cargo check --workspace --no-default-features
   features:
     runs-on: ubuntu-latest
     strategy:
@@ -40,15 +44,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Feature ${{matrix.feature}}
-        run: cargo check --no-default-features --features=${{matrix.feature}}
+        run: cargo check --workspace --no-default-features --features=${{matrix.feature}}
       - name: Feature ${{matrix.feature}}
-        run: cargo check --features=${{matrix.feature}}
+        run: cargo check --workspace --features=${{matrix.feature}}
   platforms:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, ubuntu-latest, macos-13, macos-latest, windows-2019, windows-latest ]
+        os: [ ubuntu-24.04, ubuntu-24.04-arm, ubuntu-latest, macos-15-intel, macos-latest, windows-11-arm, windows-latest ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo check --workspace --no-default-features
+      # NB: we have to use either std or alloc here
+      - run: cargo check --workspace --no-default-features --features std
+      - run: cargo check --workspace --no-default-features --features alloc
   features:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -2,9 +2,15 @@ name: Codecov
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+    tags:
+      - 'v[0-9]+.*'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - develop
+      - 'v[0-9]+.*'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,11 @@
 name: Lints
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - develop
+      - 'v[0-9]+.*'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,15 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+    tags:
+      - 'v[0-9]+.*'
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
+      - develop
+      - 'v[0-9]+.*'
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
+        os: [ ubuntu-24.04, ubuntu-24.04-arm, ubuntu-latest, macos-15-intel, macos-latest, windows-11-arm, windows-latest ]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -34,4 +40,4 @@ jobs:
       - name: Add wasm32 target
         run: rustup target add wasm32-unknown-unknown
       - name: Test in headless Chrome
-        run: wasm-pack test --headless --chrome ${{matrix.package}} --all-features
+        run: RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack test --headless --chrome ${{matrix.package}} --all-features

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,6 +1,11 @@
 edition = "2024"
 style_edition = "2024"
 
+max_width = 100
+array_width = 100
+attr_fn_like_width = 100
+fn_call_width = 100
+
 format_code_in_doc_comments = true
 format_macro_matchers = true
 format_macro_bodies = true
@@ -12,6 +17,10 @@ use_field_init_shorthand = true
 use_try_shorthand = true
 wrap_comments = true
 unstable_features = true
+where_single_line = true
+empty_item_single_line = true
+binop_separator = "Back"
+fn_single_line = true
 
 imports_granularity = "Module"
 group_imports = "StdExternalCrate"

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,13 +1,7 @@
-edition = "2021"
-version = "Two"
-
-max_width = 100
-array_width = 100
-attr_fn_like_width = 100
-fn_call_width = 100
+edition = "2024"
+style_edition = "2024"
 
 format_code_in_doc_comments = true
-fn_single_line = true
 format_macro_matchers = true
 format_macro_bodies = true
 format_strings = true
@@ -17,11 +11,7 @@ reorder_modules = false
 use_field_init_shorthand = true
 use_try_shorthand = true
 wrap_comments = true
-where_single_line = true
 unstable_features = true
-empty_item_single_line = true
-
-binop_separator = "Back"
 
 imports_granularity = "Module"
 group_imports = "StdExternalCrate"

--- a/apfloat/src/ieee.rs
+++ b/apfloat/src/ieee.rs
@@ -21,8 +21,8 @@ use std::vec::Vec;
 use amplify_num::u256;
 
 use crate::{
-    Category, ExpInt, Float, FloatConvert, ParseError, Round, Status, StatusAnd, IEK_INF, IEK_NAN,
-    IEK_ZERO,
+    Category, ExpInt, Float, FloatConvert, IEK_INF, IEK_NAN, IEK_ZERO, ParseError, Round, Status,
+    StatusAnd,
 };
 
 #[must_use]
@@ -2327,7 +2327,7 @@ mod sig {
     use core::cmp::Ordering;
     use core::mem;
 
-    use super::{limbs_for_bits, ExpInt, Limb, Loss, LIMB_BITS};
+    use super::{ExpInt, LIMB_BITS, Limb, Loss, limbs_for_bits};
 
     pub(super) fn is_all_zeros(limbs: &[Limb]) -> bool { limbs.iter().all(|&l| l.is_zero()) }
 

--- a/apfloat/src/ppc.rs
+++ b/apfloat/src/ppc.rs
@@ -14,7 +14,7 @@ use core::ops::Neg;
 
 use amplify_num::u256;
 
-use crate::{ieee, Category, ExpInt, Float, FloatConvert, ParseError, Round, Status, StatusAnd};
+use crate::{Category, ExpInt, Float, FloatConvert, ParseError, Round, Status, StatusAnd, ieee};
 
 #[must_use]
 #[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Debug)]

--- a/apfloat/tests/ieee.rs
+++ b/apfloat/tests/ieee.rs
@@ -16,7 +16,7 @@ extern crate amplify_num;
 
 use amplify_apfloat::ieee::{Double, Half, Oct, Quad, Single, X87DoubleExtended};
 use amplify_apfloat::{
-    Category, ExpInt, Float, FloatConvert, ParseError, Round, Status, IEK_INF, IEK_NAN, IEK_ZERO,
+    Category, ExpInt, Float, FloatConvert, IEK_INF, IEK_NAN, IEK_ZERO, ParseError, Round, Status,
 };
 use amplify_num::{i256, u256};
 

--- a/apfloat/tests/ieee.rs
+++ b/apfloat/tests/ieee.rs
@@ -8,6 +8,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(clippy::approx_constant)]
+
 #[macro_use]
 extern crate amplify_apfloat;
 extern crate amplify_num;

--- a/num/src/lib.rs
+++ b/num/src/lib.rs
@@ -1,7 +1,7 @@
 // Rust language amplification library providing multiple generic trait
 // implementations, type wrappers, derive macros and other language enhancements
 //
-// Written in 2020-2024 by
+// Written in 2020-2026 by
 //     Dr. Maxim Orlovsky <orlovsky@ubideco.org>
 //
 // To the extent possible under law, the author(s) have dedicated all
@@ -13,15 +13,15 @@
 // along with this software.
 // If not, see <https://opensource.org/licenses/MIT>.
 
-//! Custom-sized numeric types
+//! Custom-sized numeric types.
 //!
-//! Implementation of a various integer types with custom bit dimension. This
+//! Implementation of various integer types with custom bit dimension. This
 //! includes:
 //! * large signed and unsigned integers, named *large int types* (256, 512,
 //!   1024-bit)
-//! * custom sub-8 bit unsigned integers, named *small int types* (from 1 to
+//! * custom sub-8-bit unsigned integers, named *small int types* (from 1 to
 //!   7-bit)
-//! * 24-, 40-, 48- and 56-bit unsigned integer.
+//! * 12-, 14-, 20-, 24-, 40-, 48- and 56-bit unsigned integer.
 //!
 //! The functions here are designed to be fast.
 
@@ -42,7 +42,7 @@ pub mod posit;
 mod smallint;
 
 pub use bigint::{i1024, i256, i512, u1024, u256, u512};
-pub use smallint::{u1, u2, u24, u3, u4, u40, u48, u5, u56, u6, u7};
+pub use smallint::{u1, u2, u24, u3, u4, u40, u48, u5, u56, u6, u7, u10, u12, u14, u20};
 
 // TODO: Create arbitrary precision types
 // TODO: Move from using `u64` to `u128` for big int types

--- a/num/src/lib.rs
+++ b/num/src/lib.rs
@@ -41,8 +41,8 @@ pub mod hex;
 pub mod posit;
 mod smallint;
 
-pub use bigint::{i1024, i256, i512, u1024, u256, u512};
-pub use smallint::{u1, u2, u24, u3, u4, u40, u48, u5, u56, u6, u7, u10, u12, u14, u20};
+pub use bigint::{i256, i512, i1024, u256, u512, u1024};
+pub use smallint::{u1, u2, u3, u4, u5, u6, u7, u10, u12, u14, u20, u24, u40, u48, u56};
 
 // TODO: Create arbitrary precision types
 // TODO: Move from using `u64` to `u128` for big int types

--- a/num/src/lib.rs
+++ b/num/src/lib.rs
@@ -21,7 +21,7 @@
 //!   1024-bit)
 //! * custom sub-8-bit unsigned integers, named *small int types* (from 1 to
 //!   7-bit)
-//! * 12-, 14-, 20-, 24-, 40-, 48- and 56-bit unsigned integer.
+//! * 10-, 12-, 14-, 20-, 24-, 40-, 48- and 56-bit unsigned integer.
 //!
 //! The functions here are designed to be fast.
 

--- a/num/src/posit.rs
+++ b/num/src/posit.rs
@@ -14,7 +14,7 @@
 // If not, see <https://opensource.org/licenses/MIT>.
 
 use crate::error::PositDecodeError;
-use crate::{u1024, u256, u512};
+use crate::{u256, u512, u1024};
 
 macro_rules! construct_posit {
     (

--- a/num/src/smallint.rs
+++ b/num/src/smallint.rs
@@ -356,6 +356,42 @@ construct_smallint!(
     doc = "7-bit unsigned integer in the range `0..128`"
 );
 construct_smallint!(
+    u10,
+    u16,
+    to_u16,
+    into_u16,
+    10,
+    0x3_FF,
+    doc = "10-bit unsigned integer in the range `0..1024`"
+);
+construct_smallint!(
+    u12,
+    u16,
+    to_u16,
+    into_u16,
+    12,
+    0xF_FF,
+    doc = "12-bit unsigned integer in the range `0..4096`"
+);
+construct_smallint!(
+    u14,
+    u16,
+    to_u16,
+    into_u16,
+    14,
+    0x3F_FF,
+    doc = "14-bit unsigned integer in the range `0..16384`"
+);
+construct_smallint!(
+    u20,
+    u32,
+    to_u32,
+    into_u32,
+    20,
+    0xF_FF_FF,
+    doc = "20-bit unsigned integer in the range `0..1_048_576`"
+);
+construct_smallint!(
     u24,
     u32,
     to_u32,
@@ -474,6 +510,118 @@ impl From<u5> for u7 {
 
 impl From<u6> for u7 {
     fn from(value: u6) -> Self { Self(value.0) }
+}
+
+impl From<u10> for i32 {
+    fn from(val: u10) -> Self { val.0 as i32 }
+}
+
+impl From<u10> for i64 {
+    fn from(val: u10) -> Self { val.0 as i64 }
+}
+
+impl From<u10> for i128 {
+    fn from(val: u10) -> Self { val.0 as i128 }
+}
+
+impl From<u10> for isize {
+    fn from(val: u10) -> Self { val.0 as isize }
+}
+
+impl From<u10> for u64 {
+    fn from(val: u10) -> Self { val.0 as u64 }
+}
+
+impl From<u10> for u128 {
+    fn from(val: u10) -> Self { val.0 as u128 }
+}
+
+impl From<u10> for usize {
+    fn from(val: u10) -> Self { val.0 as usize }
+}
+
+impl From<u12> for i32 {
+    fn from(val: u12) -> Self { val.0 as i32 }
+}
+
+impl From<u12> for i64 {
+    fn from(val: u12) -> Self { val.0 as i64 }
+}
+
+impl From<u12> for i128 {
+    fn from(val: u12) -> Self { val.0 as i128 }
+}
+
+impl From<u12> for isize {
+    fn from(val: u12) -> Self { val.0 as isize }
+}
+
+impl From<u12> for u64 {
+    fn from(val: u12) -> Self { val.0 as u64 }
+}
+
+impl From<u12> for u128 {
+    fn from(val: u12) -> Self { val.0 as u128 }
+}
+
+impl From<u12> for usize {
+    fn from(val: u12) -> Self { val.0 as usize }
+}
+
+impl From<u14> for i32 {
+    fn from(val: u14) -> Self { val.0 as i32 }
+}
+
+impl From<u14> for i64 {
+    fn from(val: u14) -> Self { val.0 as i64 }
+}
+
+impl From<u14> for i128 {
+    fn from(val: u14) -> Self { val.0 as i128 }
+}
+
+impl From<u14> for isize {
+    fn from(val: u14) -> Self { val.0 as isize }
+}
+
+impl From<u14> for u64 {
+    fn from(val: u14) -> Self { val.0 as u64 }
+}
+
+impl From<u14> for u128 {
+    fn from(val: u14) -> Self { val.0 as u128 }
+}
+
+impl From<u14> for usize {
+    fn from(val: u14) -> Self { val.0 as usize }
+}
+
+impl From<u20> for i32 {
+    fn from(val: u20) -> Self { val.0 as i32 }
+}
+
+impl From<u20> for i64 {
+    fn from(val: u20) -> Self { val.0 as i64 }
+}
+
+impl From<u20> for i128 {
+    fn from(val: u20) -> Self { val.0 as i128 }
+}
+
+impl From<u20> for isize {
+    fn from(val: u20) -> Self { val.0 as isize }
+}
+
+impl From<u20> for u64 {
+    fn from(val: u20) -> Self { val.0 as u64 }
+}
+
+impl From<u20> for u128 {
+    fn from(val: u20) -> Self { val.0 as u128 }
+}
+
+impl From<u20> for usize {
+    fn from(val: u20) -> Self { val.0 as usize }
 }
 
 impl From<u24> for i32 {
@@ -720,6 +868,10 @@ mod test {
         let mut u_5 = u5::try_from(u5::MAX.to_u8()).unwrap();
         let mut u_6 = u6::try_from(u6::MAX.to_u8()).unwrap();
         let mut u_7 = u7::try_from(u7::MAX.to_u8()).unwrap();
+        let mut u_10 = u10::try_from(u10::MAX.to_u16()).unwrap();
+        let mut u_12 = u12::try_from(u12::MAX.to_u16()).unwrap();
+        let mut u_14 = u14::try_from(u14::MAX.to_u16()).unwrap();
+        let mut u_20 = u20::try_from(u20::MAX.to_u32()).unwrap();
         let mut u_24 = u24::try_from(u24::MAX.to_u32()).unwrap();
 
         assert_eq!(u_1, u1::with(1));
@@ -729,6 +881,11 @@ mod test {
         assert_eq!(u_5, u5::with(31));
         assert_eq!(u_6, u6::with(63));
         assert_eq!(u_7, u7::with(127));
+        assert_eq!(u_10, u10::with(0x3FF));
+        assert_eq!(u_12, u12::with(0xFFF));
+        assert_eq!(u_14, u14::with(0x3FFF));
+        assert_eq!(u_20, u20::with(0xF_FF_FF));
+        assert_eq!(u_24, u24::with(0xFF_FF_FF));
 
         assert_eq!(u_1.to_u8(), 1u8);
         assert_eq!(u_2.to_u8(), 3u8);
@@ -737,6 +894,10 @@ mod test {
         assert_eq!(u_5.to_u8(), 31u8);
         assert_eq!(u_6.to_u8(), 63u8);
         assert_eq!(u_7.to_u8(), 127u8);
+        assert_eq!(u_10.to_u16(), (1 << 10) - 1);
+        assert_eq!(u_12.to_u16(), (1 << 12) - 1);
+        assert_eq!(u_14.to_u16(), (1 << 14) - 1);
+        assert_eq!(u_20.to_u32(), (1 << 20) - 1);
         assert_eq!(u_24.to_u32(), (1 << 24) - 1);
 
         u_1 -= 1;
@@ -746,6 +907,10 @@ mod test {
         u_5 -= 1;
         u_6 -= 1;
         u_7 -= 1;
+        u_10 -= 1u16;
+        u_12 -= 1u16;
+        u_14 -= 1u16;
+        u_20 -= 1u32;
         u_24 -= 1u32;
 
         assert_eq!(u_1.to_u8(), 0u8);
@@ -755,6 +920,10 @@ mod test {
         assert_eq!(u_5.to_u8(), 30u8);
         assert_eq!(u_6.to_u8(), 62u8);
         assert_eq!(u_7.to_u8(), 126u8);
+        assert_eq!(u_10.to_u16(), (1 << 10) - 2);
+        assert_eq!(u_12.to_u16(), (1 << 12) - 2);
+        assert_eq!(u_14.to_u16(), (1 << 14) - 2);
+        assert_eq!(u_20.to_u32(), (1 << 20) - 2);
         assert_eq!(u_24.to_u32(), (1 << 24) - 2);
 
         u_1 /= 2;
@@ -785,6 +954,22 @@ mod test {
         u_7 *= 2;
         u_7 += 1;
 
+        u_10 /= 2u16;
+        u_10 *= 2u16;
+        u_10 += 1u16;
+
+        u_12 /= 2u16;
+        u_12 *= 2u16;
+        u_12 += 1u16;
+
+        u_14 /= 2u16;
+        u_14 *= 2u16;
+        u_14 += 1u16;
+
+        u_20 /= 2u32;
+        u_20 *= 2u32;
+        u_20 += 1u32;
+
         u_24 /= 2u32;
         u_24 *= 2u32;
         u_24 += 1u32;
@@ -796,6 +981,10 @@ mod test {
         assert_eq!(u_5.to_u8(), 31u8);
         assert_eq!(u_6.to_u8(), 63u8);
         assert_eq!(u_7.to_u8(), 127u8);
+        assert_eq!(u_10.to_u16(), (1 << 10) - 1);
+        assert_eq!(u_12.to_u16(), (1 << 12) - 1);
+        assert_eq!(u_14.to_u16(), (1 << 14) - 1);
+        assert_eq!(u_20.to_u32(), (1 << 20) - 1);
         assert_eq!(u_24.to_u32(), (1 << 24) - 1);
 
         assert_eq!(u_1.to_u8() % 2, 1);
@@ -805,6 +994,10 @@ mod test {
         assert_eq!(u_5.to_u8() % 2, 1);
         assert_eq!(u_6.to_u8() % 2, 1);
         assert_eq!(u_7.to_u8() % 2, 1);
+        assert_eq!(u_10.to_u16() % 2, 1);
+        assert_eq!(u_12.to_u16() % 2, 1);
+        assert_eq!(u_14.to_u16() % 2, 1);
+        assert_eq!(u_20.to_u32() % 2, 1);
         assert_eq!(u_24.to_u32() % 2, 1);
     }
 
@@ -835,6 +1028,22 @@ mod test {
     #[test]
     #[should_panic(expected = "OverflowError { max: 127, value: 128 }")]
     fn u7_overflow_test() { u7::try_from(128).unwrap(); }
+
+    #[test]
+    #[should_panic(expected = "OverflowError { max: 1023, value: 1024 }")]
+    fn u10_overflow_test() { u10::try_from(1 << 10).unwrap(); }
+
+    #[test]
+    #[should_panic(expected = "OverflowError { max: 4095, value: 4096 }")]
+    fn u12_overflow_test() { u12::try_from(1 << 12).unwrap(); }
+
+    #[test]
+    #[should_panic(expected = "OverflowError { max: 16383, value: 16384 }")]
+    fn u14_overflow_test() { u14::try_from(1 << 14).unwrap(); }
+
+    #[test]
+    #[should_panic(expected = "OverflowError { max: 1048575, value: 1048576 }")]
+    fn u20_overflow_test() { u20::try_from(1 << 20).unwrap(); }
 
     #[test]
     #[should_panic(expected = "OverflowError { max: 16777215, value: 16777216 }")]
@@ -880,6 +1089,10 @@ mod test {
         let u_5 = u5::MAX;
         let u_6 = u6::MAX;
         let u_7 = u7::MAX;
+        let u_10 = u10::MAX;
+        let u_12 = u12::MAX;
+        let u_14 = u14::MAX;
+        let u_20 = u20::MAX;
         let u_24 = u24::MAX;
 
         // UpperHex
@@ -890,7 +1103,12 @@ mod test {
         assert_eq!(format!("{:X}", u_5), "1F");
         assert_eq!(format!("{:X}", u_6), "3F");
         assert_eq!(format!("{:X}", u_7), "7F");
+        assert_eq!(format!("{:X}", u_10), "3FF");
+        assert_eq!(format!("{:X}", u_12), "FFF");
+        assert_eq!(format!("{:X}", u_14), "3FFF");
+        assert_eq!(format!("{:X}", u_20), "FFFFF");
         assert_eq!(format!("{:X}", u_24), "FFFFFF");
+
         assert_eq!(format!("{:#X}", u_1), "0x1");
         assert_eq!(format!("{:#X}", u_2), "0x3");
         assert_eq!(format!("{:#X}", u_3), "0x7");
@@ -898,6 +1116,10 @@ mod test {
         assert_eq!(format!("{:#X}", u_5), "0x1F");
         assert_eq!(format!("{:#X}", u_6), "0x3F");
         assert_eq!(format!("{:#X}", u_7), "0x7F");
+        assert_eq!(format!("{:#X}", u_10), "0x3FF");
+        assert_eq!(format!("{:#X}", u_12), "0xFFF");
+        assert_eq!(format!("{:#X}", u_14), "0x3FFF");
+        assert_eq!(format!("{:#X}", u_20), "0xFFFFF");
         assert_eq!(format!("{:#X}", u_24), "0xFFFFFF");
 
         // LowerHex
@@ -908,7 +1130,12 @@ mod test {
         assert_eq!(format!("{:x}", u_5), "1f");
         assert_eq!(format!("{:x}", u_6), "3f");
         assert_eq!(format!("{:x}", u_7), "7f");
+        assert_eq!(format!("{:x}", u_10), "3ff");
+        assert_eq!(format!("{:x}", u_12), "fff");
+        assert_eq!(format!("{:x}", u_14), "3fff");
+        assert_eq!(format!("{:x}", u_20), "fffff");
         assert_eq!(format!("{:x}", u_24), "ffffff");
+
         assert_eq!(format!("{:#x}", u_1), "0x1");
         assert_eq!(format!("{:#x}", u_2), "0x3");
         assert_eq!(format!("{:#x}", u_3), "0x7");
@@ -916,6 +1143,10 @@ mod test {
         assert_eq!(format!("{:#x}", u_5), "0x1f");
         assert_eq!(format!("{:#x}", u_6), "0x3f");
         assert_eq!(format!("{:#x}", u_7), "0x7f");
+        assert_eq!(format!("{:#x}", u_10), "0x3ff");
+        assert_eq!(format!("{:#x}", u_12), "0xfff");
+        assert_eq!(format!("{:#x}", u_14), "0x3fff");
+        assert_eq!(format!("{:#x}", u_20), "0xfffff");
         assert_eq!(format!("{:#x}", u_24), "0xffffff");
 
         // Octal
@@ -926,7 +1157,12 @@ mod test {
         assert_eq!(format!("{:o}", u_5), "37");
         assert_eq!(format!("{:o}", u_6), "77");
         assert_eq!(format!("{:o}", u_7), "177");
+        assert_eq!(format!("{:o}", u_10), "1777");
+        assert_eq!(format!("{:o}", u_12), "7777");
+        assert_eq!(format!("{:o}", u_14), "37777");
+        assert_eq!(format!("{:o}", u_20), "3777777");
         assert_eq!(format!("{:o}", u_24), "77777777");
+
         assert_eq!(format!("{:#o}", u_1), "0o1");
         assert_eq!(format!("{:#o}", u_2), "0o3");
         assert_eq!(format!("{:#o}", u_3), "0o7");
@@ -934,6 +1170,10 @@ mod test {
         assert_eq!(format!("{:#o}", u_5), "0o37");
         assert_eq!(format!("{:#o}", u_6), "0o77");
         assert_eq!(format!("{:#o}", u_7), "0o177");
+        assert_eq!(format!("{:#o}", u_10), "0o1777");
+        assert_eq!(format!("{:#o}", u_12), "0o7777");
+        assert_eq!(format!("{:#o}", u_14), "0o37777");
+        assert_eq!(format!("{:#o}", u_20), "0o3777777");
         assert_eq!(format!("{:#o}", u_24), "0o77777777");
 
         // Binary
@@ -944,7 +1184,12 @@ mod test {
         assert_eq!(format!("{:b}", u_5), "11111");
         assert_eq!(format!("{:b}", u_6), "111111");
         assert_eq!(format!("{:b}", u_7), "1111111");
+        assert_eq!(format!("{:b}", u_10), "1111111111");
+        assert_eq!(format!("{:b}", u_12), "111111111111");
+        assert_eq!(format!("{:b}", u_14), "11111111111111");
+        assert_eq!(format!("{:b}", u_20), "11111111111111111111");
         assert_eq!(format!("{:b}", u_24), "111111111111111111111111");
+
         assert_eq!(format!("{:#b}", u_1), "0b1");
         assert_eq!(format!("{:#b}", u_2), "0b11");
         assert_eq!(format!("{:#b}", u_3), "0b111");
@@ -952,6 +1197,10 @@ mod test {
         assert_eq!(format!("{:#b}", u_5), "0b11111");
         assert_eq!(format!("{:#b}", u_6), "0b111111");
         assert_eq!(format!("{:#b}", u_7), "0b1111111");
+        assert_eq!(format!("{:#b}", u_10), "0b1111111111");
+        assert_eq!(format!("{:#b}", u_12), "0b111111111111");
+        assert_eq!(format!("{:#b}", u_14), "0b11111111111111");
+        assert_eq!(format!("{:#b}", u_20), "0b11111111111111111111");
         assert_eq!(format!("{:#b}", u_24), "0b111111111111111111111111");
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added four new unsigned small-integer types: u10, u12, u14, and u20 for space-efficient numeric storage.
  * Implemented conversions from these new types to standard Rust integers (i32, i64, i128, isize, u64, u128, usize).

* **Documentation**
  * Updated crate documentation and package metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rust-amplify/amplify-num/pull/29)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->